### PR TITLE
Feature h5migrate

### DIFF
--- a/nucleon_elastic_ff/data/scripts/h5migrate.py
+++ b/nucleon_elastic_ff/data/scripts/h5migrate.py
@@ -1,0 +1,110 @@
+"""Script for time averaging correlator data
+"""
+import h5py
+
+import numpy as np
+
+from nucleon_elastic_ff.utilities import set_up_logger
+
+from nucleon_elastic_ff.data.h5io import get_dsets
+from nucleon_elastic_ff.data.h5io import create_dset
+
+LOGGER = set_up_logger("nucleon_elastic_ff")
+
+
+def dset_migrate(  # pylint: disable=R0914, R0913
+    inp_file: str, out_file: str, atol: float = 0.0, rtol: float = 1.0e-8,
+):
+    """Reads h5 file and copies dsets from first into second.
+
+    If dset exists, they are compared first (`|inp-out|<=atol + rtol*|out|`).
+    If they do not agree the user will be warned about that.
+    Only dsets which don't contain NaNs will be written. Dsets with NaNs raise an error.
+
+        **Arguments**
+            inp_file: str
+                H5 file to copy dsets from.
+
+            out_file: str
+                H5 file to insert dsets into.
+
+            atol:float
+                Absolute tolarance for comparison.
+
+            rtol:float
+                Relative tolarance for comparison.
+
+
+    """
+    dsets_paths = {}
+    n_dsets = {}
+    dset_meta = {}
+
+    LOGGER.info("Starting migration file `%s` into `%s`", inp_file, out_file)
+
+    LOGGER.info("Start parsing files")
+
+    with h5py.File(inp_file, "r") as h5i:
+        dsets_inp = get_dsets(h5i, load_dsets=False)
+        with h5py.File(out_file, "r+") as h5o:
+            dsets_out = get_dsets(h5o, load_dsets=False)
+
+            for key, dset in dsets_inp.items():
+                LOGGER.debug("\tParsing dset `%s`", key)
+                data = dset[()]
+                meta = dset.attrs.get("meta", None)
+
+                if np.isnan(data).any():
+                    raise ValueError(
+                        f"Dataset `{key}` in `{inp_file}` has NaN values. Aboard."
+                    )
+
+                if key not in dsets_out:
+                    LOGGER.debug("\t\tWriting dset.")
+                    create_dset(h5o, key, data, overwrite=False)
+                    if meta is not None:
+                        h5o[key].attrs["meta"] = meta
+                else:
+                    if not np.allclose(data, dsets_out[key][()], rtol=rtol, atol=atol):
+                        LOGGER.warning(
+                            "Dset `%s` in input file `%s` does not aggree with file `%s`"
+                            " for atol=%g and rtol=%g",
+                            key,
+                            inp_file,
+                            out_file,
+                            atol,
+                            rtol,
+                        )
+                    else:
+                        LOGGER.debug("\t\tDset present and equal.")
+
+
+def main():
+    """Runs dset_migrate for argparse input
+    """
+    from argparse import ArgumentParser  # pylint: disable=C0415
+
+    PARSER = ArgumentParser(description=dset_migrate.__doc__)
+    PARSER.add_argument("inp_file", type=str, help="Address to input h5file.")
+    PARSER.add_argument("out_file", type=str, help="Address to output h5file.")
+    PARSER.add_argument(
+        "--atol",
+        "-a",
+        type=float,
+        default=0.0,
+        help="Absolute comparison difference (default = [%(default)s]).",
+    )
+    PARSER.add_argument(
+        "--rtol",
+        "-r",
+        type=float,
+        default=1.0e-7,
+        help="Absolute comparison difference (default = [%(default)s]).",
+    )
+    args = PARSER.parse_args()
+
+    dset_migrate(args.inp_file, args.out_file, atol=args.atol, rtol=args.rtol)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/c51_mdwf_hisq.py
+++ b/scripts/c51_mdwf_hisq.py
@@ -88,7 +88,7 @@ ens_dir     = manage +'/production/%(ENS_S)s'
 script_dir  = manage +'/production/nucleon_elastic_FF/scripts'
 metaq_dir   = manage +'/metaq'
 #data_dir   = manage +'/production/%(ENS_S)s/data'
-data_dir    = scratch+'/production/%(ENS_S)s/data'
+data_dir    = scratch+'/production/%(ENS_S)s/tmp_data'
 data_dir_4d = scratch+'/production/%(ENS_S)s/data_4D'
 ff_data_dir = scratch+'/production/%(ENS_S)s/ff4D_data'
 

--- a/scripts/get_res_phi.py
+++ b/scripts/get_res_phi.py
@@ -84,6 +84,7 @@ else:
 print('MINING MRES and PHI_QQ')
 print('ens_stream = ',ens_s)
 print('srcs:',src_ext)
+print('data dir',data_dir)
 
 for cfg in cfgs_run:
     no = str(cfg)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
             "h5fft=nucleon_elastic_ff.data.scripts.fft:main",
             "h5concat=nucleon_elastic_ff.data.scripts.concat:main",
             "h5avg=nucleon_elastic_ff.data.scripts.average:main",
+            "h5migrate=nucleon_elastic_ff.data.scripts.h5migrate:main",
         ]
     },
     setup_requires=["pytest-runner"],

--- a/tests/nucleon_ff_data/data/scripts/h5migrate_test.py
+++ b/tests/nucleon_ff_data/data/scripts/h5migrate_test.py
@@ -1,0 +1,68 @@
+"""Tests for h5migrate
+"""
+import os
+
+from unittest import TestCase
+
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import h5py
+
+from nucleon_elastic_ff.utilities import set_up_logger
+
+from nucleon_elastic_ff.data.h5io import get_dsets
+
+from nucleon_elastic_ff.data.scripts.h5migrate import dset_migrate
+
+
+TESTDIR = os.path.join(os.getcwd(), "tests")
+
+LOGFILE = "nucleon_elastic_ff_test"
+LOGGER = set_up_logger(LOGFILE, mode="w")
+
+
+class MigrateDsetsTest(TestCase):
+    """Tests different migration scenarios
+    """
+
+    _tmp_dir = None
+
+    @property
+    def tmp_address(self):
+        """Returns address of temporary folder.
+        """
+        return self._tmp_dir.name
+
+    def setUp(self):
+        """Sets up directories and fake files.
+        """
+        self._tmp_dir = TemporaryDirectory(dir=TESTDIR)
+        np.random.seed(42)
+        LOGGER.info("Creating temp dir `%s`", self.tmp_address)
+
+        self.dset_shapes = {"dset_1": (10, 5, 2, 1), "group1/dset_2": (10, 3, 1)}
+
+        self.dsets = {}
+        self.file_inp = os.path.join(self.tmp_address, "test_in.h5")
+        with h5py.File(self.file_inp, "w") as h5f:
+            for key, shape in self.dset_shapes.items():
+                array = np.random.normal(size=shape)
+                self.dsets[key] = array
+                h5f.create_dataset(key, data=array)
+
+    def test_01_migrate_no_overlap(self):
+        """Migrates data for file with no overlap.
+        """
+        dsets = self.dsets.copy()
+        key = "dset_3"
+        dsets[key] = np.random.normal(size=(1, 2, 3))
+        file_out = os.path.join(self.tmp_address, "test_out.h5")
+        with h5py.File(file_out, "w") as h5f:
+            h5f.create_dataset(key, data=dsets[key])
+
+        dset_migrate(self.file_inp, file_out)
+
+        with h5py.File(file_out, "r") as h5f:
+            for key, dset in get_dsets(h5f, load_dsets=True).items():
+                np.testing.assert_array_equal(dsets[key], dset)

--- a/tests/nucleon_ff_data/data/scripts/h5migrate_test.py
+++ b/tests/nucleon_ff_data/data/scripts/h5migrate_test.py
@@ -3,6 +3,7 @@
 import os
 
 from unittest import TestCase
+from unittest.mock import patch
 
 from tempfile import TemporaryDirectory
 
@@ -66,3 +67,73 @@ class MigrateDsetsTest(TestCase):
         with h5py.File(file_out, "r") as h5f:
             for key, dset in get_dsets(h5f, load_dsets=True).items():
                 np.testing.assert_array_equal(dsets[key], dset)
+
+    def test_02_migrate_overlap_equal(self):
+        """Migrates data for file with overlap but files agree.
+        """
+        dsets = self.dsets.copy()
+        key = "dset_3"
+        dsets[key] = np.random.normal(size=(1, 2, 3))
+        file_out = os.path.join(self.tmp_address, "test_out.h5")
+        with h5py.File(file_out, "w") as h5f:
+            h5f.create_dataset(key, data=dsets[key])
+            h5f.create_dataset("dset_1", data=dsets["dset_1"])
+
+        dset_migrate(self.file_inp, file_out)
+
+        with h5py.File(file_out, "r") as h5f:
+            for key, dset in get_dsets(h5f, load_dsets=True).items():
+                np.testing.assert_array_equal(dsets[key], dset)
+
+    @patch("logging.Logger.warning")
+    def test_03_migrate_overlap_not_equal(self, mock):
+        """Migrates data for file with overlap and files dont agree.
+        """
+        dsets = self.dsets.copy()
+        key = "dset_3"
+        dsets[key] = np.random.normal(size=(1, 2, 3))
+        file_out = os.path.join(self.tmp_address, "test_out.h5")
+        with h5py.File(file_out, "w") as h5f:
+            h5f.create_dataset(key, data=dsets[key])
+            h5f.create_dataset("dset_1", data=dsets["dset_1"] + 1)
+
+        atol = 0.0
+        rtol = 1.0e-7
+
+        dset_migrate(self.file_inp, file_out, atol=atol, rtol=rtol)
+
+        with h5py.File(file_out, "r") as h5f:
+            for key, dset in get_dsets(h5f, load_dsets=True).items():
+                if key != "dset_1":
+                    np.testing.assert_array_equal(dsets[key], dset)
+                else:
+                    self.assertFalse(np.allclose(dsets[key], dset))
+
+        mock.assert_called_with(
+            "Dset `%s` in input file `%s` does not aggree with file `%s`"
+            " for atol=%g and rtol=%g",
+            "dset_1",
+            self.file_inp,
+            file_out,
+            atol,
+            rtol,
+        )
+
+    def test_04_migrate_nan_data(self):
+        """Migrates data for file with nan data.
+        """
+        bad_key = "bad_key"
+        bad_array = np.random.uniform(size=(3, 3, 3))
+        bad_array[0, 0, 0] = np.NaN
+        with h5py.File(self.file_inp, "w") as h5f:
+            h5f.create_dataset(bad_key, data=bad_array)
+
+        dsets = self.dsets.copy()
+        key = "dset_3"
+        dsets[key] = np.random.normal(size=(1, 2, 3))
+        file_out = os.path.join(self.tmp_address, "test_out.h5")
+        with h5py.File(file_out, "w") as h5f:
+            h5f.create_dataset(key, data=dsets[key])
+
+        with self.assertRaises(ValueError):
+            dset_migrate(self.file_inp, file_out)


### PR DESCRIPTION
Added `h5migrate` command line function and `dset_migrate` function in `nucleon_elastic_ff.data.scripts.h5migrate` including tests.

If as desired, this closes #36 